### PR TITLE
Increase operationability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6
+FROM python:3.7
 MAINTAINER Zach White <skullydazed@gmail.com>
 
 WORKDIR /qmk_api_tasks


### PR DESCRIPTION
Refactor to enable several things:

* Check queue length so we don't stress out already maxed out infrastructure.
* Add the ability to turn certain discord messages on and off
* Add a discord message telling us how big the error log is
* Add a discord message for when a compile has waited too long due to queue length
* Add timezone to our default TIME_FORMAT