### PR TITLE
Make discord messaging more featureful

### DIFF
--- a/qmk_api_tasks.py
+++ b/qmk_api_tasks.py
@@ -359,7 +359,7 @@ class TaskThread(threading.Thread):
                         bad_difference = 'No change from'
 
                     last_good_boards = good_boards
-                    last_bad_boards = good_boards
+                    last_bad_boards = bad_boards
                     qmk_redis.set('qmk_last_good_boards', good_boards)
                     qmk_redis.set('qmk_last_bad_boards', bad_boards)
 


### PR DESCRIPTION
Several enhancements to our task runner:

* New ways to control what messages are sent using environment variables:
    * `MSG_ON_LOOP_COMPLETION`
    * `MSG_ON_S3_SUCCESS`
    * `MSG_ON_S3_FAIL`
    * `MSG_ON_QMK_FAIL`
* Separate wait and timeout for when jobs are queueing instead of running
* New summary message showing how many boards pass/fail