### PR TITLE
Add warnings key to build status

### DIFF
--- a/qmk_api_tasks.py
+++ b/qmk_api_tasks.py
@@ -270,7 +270,7 @@ class TaskThread(threading.Thread):
                                 output = f'No layouts for {keyboard}! Skipping!'
                                 bad_boards += 1
                                 qmk_redis.set('qmk_bad_boards', bad_boards)
-                                configurator_build_status[keyboard] = {'works': False, 'last_tested': int(time()), 'message': output}
+                                configurator_build_status[keyboard] = {'works': False, 'warnings': False, 'last_tested': int(time()), 'message': output}
                                 keyboards_tested[keyboard] = False  # FIXME: Remove this when it's no longer used
                                 failed_keyboards[keyboard] = {'severity': 'error', 'message': output}  # FIXME: Remove this when it's no longer used
                                 print(output)
@@ -303,7 +303,7 @@ class TaskThread(threading.Thread):
                         print('Compile job completed successfully!')
                         good_boards += 1
                         qmk_redis.set('qmk_good_boards', good_boards)
-                        configurator_build_status[keyboard] = {'works': True, 'last_tested': int(time()), 'message': result['output']}
+                        configurator_build_status[keyboard] = {'works': True, 'warnings': '[WARNING]' in result['output'], 'last_tested': int(time()), 'message': result['output']}
                         keyboards_tested[keyboard] = True  # FIXME: Remove this when it's no longer used
                         if keyboard in failed_keyboards:
                             del failed_keyboards[keyboard]  # FIXME: Remove this when it's no longer used
@@ -327,7 +327,7 @@ class TaskThread(threading.Thread):
 
                         bad_boards += 1
                         qmk_redis.set('qmk_bad_boards', bad_boards)
-                        configurator_build_status[keyboard] = {'works': False, 'last_tested': int(time()), 'message': output}
+                        configurator_build_status[keyboard] = {'works': False, 'warnings': False, 'last_tested': int(time()), 'message': output}
                         keyboards_tested[keyboard] = False  # FIXME: Remove this when it's no longer used
                         failed_keyboards[keyboard] = {'severity': 'error', 'message': output}  # FIXME: Remove this when it's no longer used
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

To allow the status page to show builds that passed with warnings.
